### PR TITLE
Externalize peer deps as last step

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -11,10 +11,10 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   plugins: [
-    peerDepsExternal(),
     vue(),
     dts({ tsconfigPath: './tsconfig.app.json', rollupTypes: true }),
     vuetify({ autoImport: true }),
+    peerDepsExternal(),
   ],
   build: {
     sourcemap: true,


### PR DESCRIPTION
To make sure that the vuetify plugin does not add external imports after `peerDepsExternal()` has done its job.