### PR TITLE
Menu-like behavior

### DIFF
--- a/example/src/App.vue
+++ b/example/src/App.vue
@@ -14,7 +14,6 @@
 
 <script setup>
 import 'ol/ol.css';
-import '../../dist/style.css';
 import Map from 'ol/Map';
 import View from 'ol/View';
 import TileLayer from 'ol/layer/Tile';

--- a/src/components/PlaceSearch.vue
+++ b/src/components/PlaceSearch.vue
@@ -1,10 +1,10 @@
 <template>
-  <v-sheet class="searchContainer">
     <v-autocomplete
       v-model="model"
       v-model:search="search"
+      ref="autocompleteRef"
       auto-select-first
-      class="rounded"
+      class="rounded searchContainer"
       clearable
       :custom-filter="filter"
       density="compact"
@@ -18,9 +18,8 @@
       return-object
       single-line
       variant="outlined"
-      @blur="handleInfoVisibility(false)"
-      @click:clear="clear"
       @focus="handleInfoVisibility(true)"
+      @click:clear="clear"
     >
       <template #item="{ props, item }">
         <v-list-item
@@ -30,8 +29,9 @@
         ></v-list-item>
       </template>
     </v-autocomplete>
-    <v-expand-transition>
-      <v-card v-show="showInfo">
+
+    <v-menu v-model="showInfo" :target="autocompleteRef">
+      <v-card>
         <v-card-title>
           <v-icon :icon="mdiInformationOutline" size="small" />
           Ortssuche
@@ -62,8 +62,7 @@
           </v-timeline>
         </v-card-text>
       </v-card>
-    </v-expand-transition>
-  </v-sheet>
+    </v-menu>
 </template>
 
 <script setup>
@@ -94,6 +93,7 @@ import {
  * @property {string} id
  */
 
+const autocompleteRef = ref(null);
 const { result } = usePlaceSearch();
 const emit = defineEmits(['result']);
 

--- a/src/components/PlaceSearch.vue
+++ b/src/components/PlaceSearch.vue
@@ -1,11 +1,10 @@
 <template>
   <v-autocomplete
+    ref="autocompleteRef"
     v-model="model"
     v-model:search="search"
-    ref="autocompleteRef"
     auto-select-first
     class="rounded"
-    min-width="280px"
     clearable
     :custom-filter="filter"
     density="compact"
@@ -15,21 +14,22 @@
     :items="items"
     label="Ort, Adresse, Flurname,..."
     :loading="!!abortController"
+    min-width="280px"
     :prepend-inner-icon="mdiMagnify"
     return-object
     single-line
     variant="outlined"
-    @focus="handleInfoVisibility(true)"
     @click:clear="clear"
+    @focus="handleInfoVisibility(true)"
   >
     <template #item="{ props, item }">
       <v-list-item
         v-bind="props"
-        :key="item.raw.id"
         :id="item.raw.id"
-        :value="item.raw.id"
+        :key="item.raw.id"
         :subtitle="item.raw.type"
         :title="item.raw.properties.name"
+        :value="item.raw.id"
       ></v-list-item>
     </template>
   </v-autocomplete>

--- a/src/components/PlaceSearch.vue
+++ b/src/components/PlaceSearch.vue
@@ -24,6 +24,9 @@
       <template #item="{ props, item }">
         <v-list-item
           v-bind="props"
+          :key="item.raw.id"
+          :id="item.raw.id"
+          :value="item.raw.id"
           :subtitle="item.raw.type"
           :title="item.raw.properties.name"
         ></v-list-item>

--- a/src/components/PlaceSearch.vue
+++ b/src/components/PlaceSearch.vue
@@ -218,6 +218,6 @@ function handleInfoVisibility(visible) {
 
 <style scoped>
 .searchContainer {
-  position: relative;
+  min-width: 280px;
 }
 </style>

--- a/src/components/PlaceSearch.vue
+++ b/src/components/PlaceSearch.vue
@@ -14,7 +14,7 @@
     :items="items"
     label="Ort, Adresse, Flurname,..."
     :loading="!!abortController"
-    min-width="280px"
+    min-width="280"
     :prepend-inner-icon="mdiMagnify"
     return-object
     single-line

--- a/src/components/PlaceSearch.vue
+++ b/src/components/PlaceSearch.vue
@@ -1,71 +1,72 @@
 <template>
-    <v-autocomplete
-      v-model="model"
-      v-model:search="search"
-      ref="autocompleteRef"
-      auto-select-first
-      class="rounded searchContainer"
-      clearable
-      :custom-filter="filter"
-      density="compact"
-      hide-details
-      hide-no-data
-      item-title="properties.name"
-      :items="items"
-      label="Ort, Adresse, Flurname,..."
-      :loading="!!abortController"
-      :prepend-inner-icon="mdiMagnify"
-      return-object
-      single-line
-      variant="outlined"
-      @focus="handleInfoVisibility(true)"
-      @click:clear="clear"
-    >
-      <template #item="{ props, item }">
-        <v-list-item
-          v-bind="props"
-          :key="item.raw.id"
-          :id="item.raw.id"
-          :value="item.raw.id"
-          :subtitle="item.raw.type"
-          :title="item.raw.properties.name"
-        ></v-list-item>
-      </template>
-    </v-autocomplete>
+  <v-autocomplete
+    v-model="model"
+    v-model:search="search"
+    ref="autocompleteRef"
+    auto-select-first
+    class="rounded"
+    min-width="280px"
+    clearable
+    :custom-filter="filter"
+    density="compact"
+    hide-details
+    hide-no-data
+    item-title="properties.name"
+    :items="items"
+    label="Ort, Adresse, Flurname,..."
+    :loading="!!abortController"
+    :prepend-inner-icon="mdiMagnify"
+    return-object
+    single-line
+    variant="outlined"
+    @focus="handleInfoVisibility(true)"
+    @click:clear="clear"
+  >
+    <template #item="{ props, item }">
+      <v-list-item
+        v-bind="props"
+        :key="item.raw.id"
+        :id="item.raw.id"
+        :value="item.raw.id"
+        :subtitle="item.raw.type"
+        :title="item.raw.properties.name"
+      ></v-list-item>
+    </template>
+  </v-autocomplete>
 
-    <v-menu v-model="showInfo" :target="autocompleteRef">
-      <v-card>
-        <v-card-title>
-          <v-icon :icon="mdiInformationOutline" size="small" />
-          Ortssuche
-        </v-card-title>
-        <v-card-subtitle>
-          Die Suche des
-          <a href="https://kataster.bev.gv.at" target="_blank"
-            >Österreichischen Katasters</a
-          ><br />
-          Suche nach Orten, Adressen, und mehr
-        </v-card-subtitle>
-        <v-card-text>
-          <v-timeline align="start" density="compact" line-thickness="0">
-            <v-timeline-item
-              v-for="(helpItem, key) in helpItems"
-              :key="key"
-              density="compact"
-              dot-color="success"
-              :icon="mdiTextSearchVariant"
-            >
-              <div>
-                <div class="font-weight-normal">
-                  <strong> {{ helpItem.name }}</strong>
-                </div>
-                {{ helpItem.example }}
+  <v-menu v-model="showInfo" :target="autocompleteRef">
+    <v-card>
+      <v-card-title>
+        <v-icon :icon="mdiInformationOutline" size="small" />
+        Ortssuche
+      </v-card-title>
+      <v-card-subtitle>
+        Die Suche des
+        <a href="https://kataster.bev.gv.at" target="_blank"
+          >Österreichischen Katasters</a
+        ><br />
+        Suche nach Orten, Adressen, und mehr
+      </v-card-subtitle>
+      <v-card-text>
+        <v-timeline align="start" density="compact" line-thickness="0">
+          <v-timeline-item
+            v-for="(helpItem, key) in helpItems"
+            :key="key"
+            density="compact"
+            dot-color="success"
+            :icon="mdiTextSearchVariant"
+          >
+            <div>
+              <div class="font-weight-normal">
+                <strong> {{ helpItem.name }}</strong>
               </div>
-            </v-timeline-item>
-          </v-timeline>
-        </v-card-text>
-      </v-card>
-    </v-menu>
+              {{ helpItem.example }}
+            </div>
+          </v-timeline-item>
+        </v-timeline>
+      </v-card-text>
+    </v-card>
+  </v-menu>
 </template>
 
 <script setup>
@@ -218,9 +219,3 @@ function handleInfoVisibility(visible) {
   }
 }
 </script>
-
-<style scoped>
-.searchContainer {
-  min-width: 280px;
-}
-</style>


### PR DESCRIPTION
This PR implements changes according to #15

 - The default size has been set via the prop of the v-autocomplete, the wrapping element has been removed, as well as the now-obsolete css import of the example application. Now it should integrate like a normal `v-autocomplete`, although some styling props like `density`, `single-line` or `min-width` are set by the plugin itself.
 - The menu-like behavior is now implemented with a proper `v-menu`, that has the `v-autocomplete` as the `target`, but no `activator`, so we still have full control. `Vuetify` detaches menus from the DOM, and uses `<teleport>` to "attach" them back to the location of their target, which makes them appear over any other element, even when used in a navigation bar with `overflow: hidden`, like in the example application.
 - some good-practives have been implemented for the `v-list-item`, but there is still a well-known bug in vuetify that throws warnings for nodes with duplicate IDs inside a `v-virtual-scoll` element.